### PR TITLE
Add a TravisCi file to build on a push to master and release JARs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: java
+jdk:
+- openjdk8
+branches:
+  only:
+    - master
+cache:
+  directories:
+  - "$HOME/.m2"
+before_install:
+- export APP_VERSION="`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate
+  -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'`-$TRAVIS_BUILD_NUMBER"
+- echo $APP_VERSION
+script:
+- mvn versions:set -DnewVersion=$APP_VERSION
+- mvn clean package
+before_deploy:
+- git config --global user.email "builds@travis-ci.com"
+- git config --global user.name "Travis CI"
+- git commit -a -m "Set version to $APP_VERSION"
+- git tag $APP_VERSION -a -m "Generated tag from TravisCI for $APP_VERSION"
+- git push -q -f https://$GITHUB_API_KEY@github.com/imduffy15/keycloak-extension-playground --tags
+  --tags
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key: $GITHUB_API_KEY
+  file_glob: true
+  file: "**/target/*.jar"
+  on:
+    repo: imduffy15/keycloak-extension-playground
+    tags: false
+    branch: master

--- a/keycloak-playground-server/pom.xml
+++ b/keycloak-playground-server/pom.xml
@@ -73,9 +73,9 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
+<!--         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-testsuite-utils</artifactId>
-        </dependency>
+        </dependency> -->
     </dependencies>
 </project>

--- a/keycloak-playground-server/src/main/java/com/github/thomasdarimont/keycloak/server/KeycloakPlaygroundServer.java
+++ b/keycloak-playground-server/src/main/java/com/github/thomasdarimont/keycloak/server/KeycloakPlaygroundServer.java
@@ -1,12 +1,12 @@
-package com.github.thomasdarimont.keycloak.server;
+// package com.github.thomasdarimont.keycloak.server;
 
-import org.keycloak.testsuite.KeycloakServer;
+// import org.keycloak.testsuite.KeycloakServer;
 
-public class KeycloakPlaygroundServer {
+// public class KeycloakPlaygroundServer {
 
-    public static void main(String[] args) throws Throwable {
+//     public static void main(String[] args) throws Throwable {
 
-        System.out.println("Starting KeycloakPlaygroundServer");
-        KeycloakServer.main(args);
-    }
-}
+//         System.out.println("Starting KeycloakPlaygroundServer");
+//         KeycloakServer.main(args);
+//     }
+// }

--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,11 @@
     <dependencyManagement>
         <dependencies>
 
-            <dependency>
+<!--             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-testsuite-utils</artifactId>
                 <version>${keycloak.version}</version>
-            </dependency>
+            </dependency> -->
 
             <dependency>
                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
To make these easier to play around with, it would be nice if the
JARs were provided.

This commit adds a `.travis.yml` file that will build the project
and upload all JARs to the github releases page.

You'll need to create a github personal access token with `public_repo`
access and submit this as a secret environment variable on the travis job.

**note:** I commented out anything relating to keycloak-testsuite as I was
unable to find a maven repository serving those dependencies