### PR TITLE
port to current version of keycloak (8.0.1)

### DIFF
--- a/auth-identity-first-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/identityfirst/AbstractIdentityFirstUsernameFormAuthenticator.java
+++ b/auth-identity-first-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/identityfirst/AbstractIdentityFirstUsernameFormAuthenticator.java
@@ -14,6 +14,16 @@ import javax.ws.rs.core.Response;
 
 public abstract class AbstractIdentityFirstUsernameFormAuthenticator extends AbstractUsernameFormAuthenticator {
 
+    public boolean invalidUser(AuthenticationFlowContext context, UserModel user) {
+        if (user == null) {
+            dummyHash(context);
+            context.getEvent().error(Errors.USER_NOT_FOUND);
+            Response challengeResponse = challenge(context, Messages.INVALID_USER);
+            context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+            return true;
+        }
+        return false;
+    }
 
     protected UserModel lookupUser(AuthenticationFlowContext context, String username) {
 

--- a/auth-identity-first-extension/src/main/resources/theme/auth-identity-first-extension-theme/login/theme.properties
+++ b/auth-identity-first-extension/src/main/resources/theme/auth-identity-first-extension-theme/login/theme.properties
@@ -1,0 +1,6 @@
+parent=keycloak
+import=common/keycloak
+
+styles=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/zocial/zocial.css css/login.css css/identity-first.css
+#meta=viewport==width=device-width,initial-scale=1
+

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- dependency versions -->
-        <lombok.version>1.18.6</lombok.version>
+        <lombok.version>1.18.10</lombok.version>
 
-        <keycloak.version>7.0.1</keycloak.version>
-        <auto-service.version>1.0-rc5</auto-service.version>
+        <keycloak.version>8.0.1</keycloak.version>
+        <auto-service.version>1.0-rc6</auto-service.version>
     </properties>
 
     <dependencyManagement>

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ since the required library `keycloak-testsuite-utils` is not distributed to mave
 ## Building Keycloak  
 ```
 # The Keycloak version referenced in the pom.xml 
-KC_VERSION=7.0.0
+KC_VERSION=8.0.1
 git clone https://github.com/keycloak/keycloak
 git checkout $KC_VERSION
 mvn clean install -DskipTests
@@ -50,7 +50,7 @@ You can access the local Keycloak instance via the URL: `http://localhost:8081/a
 -Dkeycloak.profile=COMMUNITY
 -Dkeycloak.product.name=keycloak
 -Dproduct.name=keycloak
--Dproduct.version=7.0.x
+-Dproduct.version=8.0.1
 -Dkeycloak.profile=preview
 -Dkeycloak.profile.feature.account2=enabled
 -Dkeycloak.profile.feature.scripts=enabled
@@ -78,7 +78,7 @@ You can access the local Keycloak instance via the URL: `http://localhost:8081/a
 -Dkeycloak.profile=COMMUNITY
 -Dkeycloak.product.name=keycloak
 -Dproduct.name=keycloak
--Dproduct.version=7.0.x
+-Dproduct.version=8.0.1
 -Dkeycloak.profile=preview
 -Dkeycloak.profile.feature.account2=enabled
 -Dkeycloak.profile.feature.scripts=enabled


### PR DESCRIPTION
- updates to use keycloak 8.0.1 in pom.
- added back `invalidUser()` method to `AbstractIdentityFirstUsernameFormAuthenticator` because of removal in keycloak 8.
- added `theme.properties` file to `auth-identity-first-extension-theme` so theme inheritance works properly.