### PR TITLE
Consider deep role mappings when verifying user roles in auth-require-role-extension

### DIFF
--- a/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleAuthenticator.java
+++ b/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleAuthenticator.java
@@ -46,7 +46,7 @@ public class RequireRoleAuthenticator implements Authenticator {
 
         RoleModel role = getRoleFromString(realm, roleName);
 
-        return RoleUtils.hasRole(user.getRoleMappings(), role);
+        return RoleUtils.hasRole(RoleUtils.getDeepUserRoleMappings(user), role);
     }
 
 


### PR DESCRIPTION
A user can have permission to use a role even if the role is not attached to the user directly. For example, a user might be in a group that has access to a role, or a user might have access to a role through composite roles.

Luckily RoleUtils has a function to resolve deep user role mappings.

- https://www.keycloak.org/docs-api/9.0/javadocs/org/keycloak/models/utils/RoleUtils.html