### PR TITLE
Derived Require-Role-Authenticator for usage with direct grant

### DIFF
--- a/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleAuthenticator.java
+++ b/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleAuthenticator.java
@@ -22,7 +22,7 @@ import static org.keycloak.models.utils.KeycloakModelUtils.getRoleFromString;
  */
 public class RequireRoleAuthenticator implements Authenticator {
 
-    private static final Logger LOG = Logger.getLogger(RequireRoleAuthenticator.class);
+    protected static final Logger LOG = Logger.getLogger(RequireRoleAuthenticator.class);
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
@@ -50,7 +50,7 @@ public class RequireRoleAuthenticator implements Authenticator {
      * @param roleName
      * @return true if roleName is in any of all user role mappings including all groups of user
      */
-    private boolean userHasRole(RealmModel realm, UserModel user, String roleName) {
+    protected boolean userHasRole(RealmModel realm, UserModel user, String roleName) {
 
         if (roleName == null) {
             return false;
@@ -78,7 +78,7 @@ public class RequireRoleAuthenticator implements Authenticator {
 
     @Override
     public boolean requiresUser() {
-        return false;
+        return true;
     }
 
     @Override

--- a/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleDirectGrantAuthenticator.java
+++ b/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleDirectGrantAuthenticator.java
@@ -1,0 +1,45 @@
+package com.github.thomasdarimont.keycloak.auth.requirerole;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Simple {@link Authenticator} that checks if the user has a given {@link RoleModel Role} and return correct error for usage in direct grant flow.
+ */
+public class RequireRoleDirectGrantAuthenticator extends RequireRoleAuthenticator {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+
+        AuthenticatorConfigModel configModel = context.getAuthenticatorConfig();
+
+        String roleName = configModel.getConfig().get(RequireRoleDirectGrantAuthenticatorFactory.ROLE);
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getUser();
+
+        if (userHasRole(realm, user, roleName)) {
+            context.success();
+            return;
+        }
+
+        LOG.debugf("Access denied because of missing role. realm=%s username=%s role=%s", realm.getName(), user.getUsername(), roleName);
+        String responsePhrase = String.format("Access denied because of missing role. realm=%s username=%s role=%s", realm.getName(), user.getUsername(), roleName);
+
+        Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "missing_role", responsePhrase);
+        context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
+    }
+
+    private Response errorResponse(int status, String error, String errorDescription) {
+        OAuth2ErrorRepresentation errorRep = new OAuth2ErrorRepresentation(error, errorDescription);
+        return Response.status(status).entity(errorRep).type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+}

--- a/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleDirectGrantAuthenticatorFactory.java
+++ b/auth-require-role-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requirerole/RequireRoleDirectGrantAuthenticatorFactory.java
@@ -1,0 +1,94 @@
+package com.github.thomasdarimont.keycloak.auth.requirerole;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.keycloak.provider.ProviderConfigProperty.ROLE_TYPE;
+
+public class RequireRoleDirectGrantAuthenticatorFactory implements AuthenticatorFactory {
+
+    private static final String PROVIDER_ID = "require-role-direct-grant";
+
+    static final String ROLE = "role";
+
+    public static final RequireRoleDirectGrantAuthenticator ROLE_AUTHENTICATOR = new RequireRoleDirectGrantAuthenticator();
+
+    @Override
+    public String getDisplayType() {
+        return "Require Role for Direct Grant";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Requires the user to have a given role.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+
+        ProviderConfigProperty role = new ProviderConfigProperty();
+        role.setType(ROLE_TYPE);
+        role.setName(ROLE);
+        role.setLabel("Role");
+        role.setHelpText("Require role for direct grant.");
+
+        return Arrays.asList(role);
+    }
+
+    @Override
+    public void close() {
+        // NOOP
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return ROLE_AUTHENTICATOR;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // NOOP
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // NOOP
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/auth-require-role-extension/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/auth-require-role-extension/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,1 +1,2 @@
 com.github.thomasdarimont.keycloak.auth.requirerole.RequireRoleAuthenticatorFactory
+com.github.thomasdarimont.keycloak.auth.requirerole.RequireRoleDirectGrantAuthenticatorFactory


### PR DESCRIPTION
The exiting implementation of the 'auth-require-role'-extension is meant to be used for browser-based-flows. It fails when using it with direct-grant-based-flows.

This PR adds another authenticator that derives from the existing one. It just changes the response in case the authentication is not successful, so it can be used with direct-grant-flows.