### PR TITLE
✨ show a proper error message for auth-require-group

### DIFF
--- a/auth-require-group-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requiregroup/RequireGroupAuthenticator.java
+++ b/auth-require-group-extension/src/main/java/com/github/thomasdarimont/keycloak/auth/requiregroup/RequireGroupAuthenticator.java
@@ -3,12 +3,15 @@ package com.github.thomasdarimont.keycloak.auth.requiregroup;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;
+import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.services.messages.Messages;
 
 /**
  * Simple {@link Authenticator} that checks of a user is member of a given {@link GroupModel Group}.
@@ -27,9 +30,10 @@ public class RequireGroupAuthenticator implements Authenticator {
         UserModel user = context.getUser();
 
         if (!isMemberOfGroup(realm, user, groupPath)) {
-
             LOG.debugf("Access denied because of missing group membership. realm=%s username=%s groupPath=%s", realm.getName(), user.getUsername(), groupPath);
-            context.cancelLogin();
+            context.getEvent().user(user);
+            context.getEvent().error(Errors.NOT_ALLOWED);
+            context.forkWithErrorMessage(new FormMessage(Messages.NO_ACCESS));
             return;
         }
 


### PR DESCRIPTION
The extension was just redisplaying the login form (no error message at all) for me using keycloak 20. This extension hasn't been touched in years so the behaviour might have been different in previous versions?

I copy pasted from `AccessPolicyAuthenticator` and now I see a proper "No access" message :tada: 